### PR TITLE
[Feat] Generation 생성 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ subprojects {
 	apply(plugin = "org.jetbrains.kotlin.plugin.noarg")
 	apply(plugin = "org.springframework.boot")
 	apply(plugin = "io.spring.dependency-management")
+	apply(plugin = "java")
 
 	allOpen {
 		annotation("jakarta.persistence.Entity")
@@ -65,8 +66,8 @@ subprojects {
 	}
 
 	dependencies {
-		implementation("org.springframework.boot:spring-boot-starter-actuator")
 		implementation("org.springframework.boot:spring-boot-starter-web")
+		implementation("org.springframework.boot:spring-boot-starter-actuator")
 		implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 		implementation("io.sentry:sentry-spring-boot-starter-jakarta")
 		implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/module-api/build.gradle.kts
+++ b/module-api/build.gradle.kts
@@ -11,6 +11,15 @@ dependencies {
 	implementation(project(":module-domain"))
 	implementation(project(":module-external"))
 
+	implementation("org.springframework.boot:spring-boot-starter-jdbc")
 	implementation("org.flywaydb:flyway-core")
 	implementation("org.flywaydb:flyway-mysql")
+
+	// DB
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+	runtimeOnly("com.mysql:mysql-connector-j")
+
+	// Validation
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 }

--- a/module-api/src/main/kotlin/org/iass/generation/controller/GenerationController.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/controller/GenerationController.kt
@@ -1,0 +1,24 @@
+package org.iass.generation.controller
+
+import jakarta.validation.Valid
+import org.iass.generation.dto.request.GenerationCreateRequest
+import org.iass.generation.facade.GenerationFacade
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@RestController
+@RequestMapping("/generation")
+class GenerationController(
+	private val generationFacade: GenerationFacade
+) {
+	@PostMapping
+	fun create(
+		@Valid @RequestBody request: GenerationCreateRequest
+	): ResponseEntity<URI> {
+		return ResponseEntity.created(generationFacade.create(request)).build()
+	}
+}

--- a/module-api/src/main/kotlin/org/iass/generation/dto/request/GenerationCreateRequest.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/dto/request/GenerationCreateRequest.kt
@@ -1,20 +1,27 @@
 package org.iass.generation.dto.request
 
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
 data class GenerationCreateRequest(
+	@field:NotNull
 	@field:Positive
 	val order: Int,
+	@field:NotNull
 	@field:DateTimeFormat(pattern = "yyyy-MM-dd")
 	val startAt: LocalDate,
+	@field:NotNull
 	@field:Positive
 	val period: Int,
+	@field:NotNull
 	@field:Positive
 	val articlePenalty: Int,
+	@field:NotNull
 	@field:Positive
 	val feedbackPenalty: Int,
+	@field:NotNull
 	@field:Positive
 	val ticketCount: Int
 )

--- a/module-api/src/main/kotlin/org/iass/generation/dto/request/GenerationCreateRequest.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/dto/request/GenerationCreateRequest.kt
@@ -1,0 +1,20 @@
+package org.iass.generation.dto.request
+
+import jakarta.validation.constraints.Positive
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+data class GenerationCreateRequest(
+	@field:Positive
+	val order: Int,
+	@field:DateTimeFormat(pattern = "yyyy-MM-dd")
+	val startAt: LocalDate,
+	@field:Positive
+	val period: Int,
+	@field:Positive
+	val articlePenalty: Int,
+	@field:Positive
+	val feedbackPenalty: Int,
+	@field:Positive
+	val ticketCount: Int
+)

--- a/module-api/src/main/kotlin/org/iass/generation/facade/GenerationFacade.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/facade/GenerationFacade.kt
@@ -1,0 +1,20 @@
+package org.iass.generation.facade
+
+import org.iass.generation.dto.request.GenerationCreateRequest
+import org.iass.generation.service.GenerationCommandService
+import org.iass.generation.service.GenerationQueryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.net.URI
+
+@Service
+@Transactional(readOnly = true)
+class GenerationFacade(
+	private val generationCommandService: GenerationCommandService,
+	private val generationQueryService: GenerationQueryService
+) {
+	fun create(request: GenerationCreateRequest): URI {
+		val generation = generationCommandService.create(request)
+		return URI.create("/api/generation/${generation.id}")
+	}
+}

--- a/module-api/src/main/kotlin/org/iass/generation/service/GenerationCommandService.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/service/GenerationCommandService.kt
@@ -2,7 +2,7 @@ package org.iass.generation.service
 
 import org.iass.generation.dto.request.GenerationCreateRequest
 import org.iass.model.generation.Generation
-import org.iass.repository.generation.GenerationMongoRepository
+import org.iass.repository.generation.GenerationRepository
 import org.iass.util.RandomStringUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class GenerationCommandService(
-	private val generationMongoRepository: GenerationMongoRepository
+	private val generationRepository: GenerationRepository
 ) {
 	fun create(request: GenerationCreateRequest): Generation {
 		Generation(
@@ -22,7 +22,7 @@ class GenerationCommandService(
 			ticketCount = request.ticketCount,
 			inviteCode = RandomStringUtils.generate()
 		).let {
-			return generationMongoRepository.save(it)
+			return generationRepository.save(it)
 		}
 	}
 }

--- a/module-api/src/main/kotlin/org/iass/generation/service/GenerationCommandService.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/service/GenerationCommandService.kt
@@ -1,0 +1,28 @@
+package org.iass.generation.service
+
+import org.iass.generation.dto.request.GenerationCreateRequest
+import org.iass.model.generation.Generation
+import org.iass.repository.generation.GenerationMongoRepository
+import org.iass.util.RandomStringUtils
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class GenerationCommandService(
+	private val generationMongoRepository: GenerationMongoRepository
+) {
+	fun create(request: GenerationCreateRequest): Generation {
+		Generation(
+			order = request.order,
+			startAt = request.startAt,
+			period = request.period,
+			articlePenalty = request.articlePenalty,
+			feedbackPenalty = request.feedbackPenalty,
+			ticketCount = request.ticketCount,
+			inviteCode = RandomStringUtils.generate()
+		).let {
+			return generationMongoRepository.save(it)
+		}
+	}
+}

--- a/module-api/src/main/kotlin/org/iass/generation/service/GenerationQueryService.kt
+++ b/module-api/src/main/kotlin/org/iass/generation/service/GenerationQueryService.kt
@@ -1,0 +1,8 @@
+package org.iass.generation.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GenerationQueryService

--- a/module-common/src/main/kotlin/org/iass/util/RandomStringUtils.kt
+++ b/module-common/src/main/kotlin/org/iass/util/RandomStringUtils.kt
@@ -1,0 +1,21 @@
+package org.iass.util
+
+import java.util.concurrent.ThreadLocalRandom
+
+class RandomStringUtils {
+	companion object {
+		val random = ThreadLocalRandom.current()
+
+		fun generate(): String {
+			val key = StringBuilder()
+			for (i in 0..5) {
+				when (random.nextInt(3)) {
+					0 -> key.append((random.nextInt(26) + 97).toChar())
+					1 -> key.append((random.nextInt(26) + 65).toChar())
+					2 -> key.append(random.nextInt(10))
+				}
+			}
+			return key.toString()
+		}
+	}
+}

--- a/module-domain/src/main/kotlin/org/iass/model/generation/Generation.kt
+++ b/module-domain/src/main/kotlin/org/iass/model/generation/Generation.kt
@@ -1,4 +1,4 @@
-package org.iass.model.user
+package org.iass.model.generation
 
 import jakarta.persistence.Id
 import org.springframework.data.mongodb.core.mapping.Document

--- a/module-domain/src/main/kotlin/org/iass/model/user/User.kt
+++ b/module-domain/src/main/kotlin/org/iass/model/user/User.kt
@@ -1,6 +1,7 @@
 package org.iass.model.user
 
 import jakarta.persistence.Id
+import org.iass.model.generation.Generation
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document("user")

--- a/module-domain/src/main/kotlin/org/iass/repository/generation/GenerationMongoRepository.kt
+++ b/module-domain/src/main/kotlin/org/iass/repository/generation/GenerationMongoRepository.kt
@@ -1,0 +1,8 @@
+package org.iass.repository.generation
+
+import org.iass.model.generation.Generation
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface GenerationMongoRepository : MongoRepository<Generation, Long>

--- a/module-domain/src/main/kotlin/org/iass/repository/generation/GenerationRepository.kt
+++ b/module-domain/src/main/kotlin/org/iass/repository/generation/GenerationRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface GenerationMongoRepository : MongoRepository<Generation, Long>
+interface GenerationRepository : MongoRepository<Generation, Long>


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #7 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
Generation 생성 API를 구현하였습니다.
특별 구현 사항으로는 입장 코드를 Random 문자열로 생성하는 요구사항이었습니다. 해당 문자열을 숫자 및 문자로 이루어진 문자를 만들어내었습니다. 동시성 문제를 고려하여 Random이 아닌 ThreadLocalRandom을 사용하였고 이를 RandomStringUtils로 빼어 사용하도록 하였습니다.

또한 CommandService(POST, DELETE, PUT), CommandService(GET, HEAD)를 분리하여 설계하였습니다. 이 두 Service를 순수하게 유지하기 위해 Facade 패턴을 적용하여 해당 서비스를 이용하여 조합하도록 구현하였습니다. (현재는 조합하여 처리하는 비즈니스 로직을 구현하지 않아 직접적으로 보이지는 않습니다.)

또한 MongoDB에 document가 정상적으로 저장되는 것을 확인하였고 DTO validation까지 적용하였습니다.

이상한 부분이 있거나 궁금하신 부분은 리뷰 부탁드립니다~

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
<img width="426" alt="image" src="https://github.com/IASS-2024/IASS-SERVER/assets/48898994/a060900f-f6ce-4f0a-892a-2cc5ad007799">
